### PR TITLE
In examples, convert remaining required arguments to optional arguments

### DIFF
--- a/sapphire/__init__.py
+++ b/sapphire/__init__.py
@@ -2,8 +2,8 @@
 
 Sapphire is an engine for constructing PDE-based simulations based on
 the Firedrake framework.
-This package provides the `sapphire.Simulation` base class, along with
-packages of simulations and benchmarks using that class.
+It provides the `sapphire.Simulation` base class, along with packages 
+of general simulations and specific examples.
 
 Simulations proceed forward in time by solving a sequence of 
 initial boundary value problems (IBVP's).

--- a/sapphire/simulations/examples/freeze_water_in_cavity.py
+++ b/sapphire/simulations/examples/freeze_water_in_cavity.py
@@ -86,8 +86,9 @@ def dirichlet_boundary_conditions(sim):
 
     W = sim.function_space
     
-    return [fe.DirichletBC(
-        W.sub(1), (0.,)*sim.mesh.geometric_dimension(), "on_boundary"),
+    return [
+        fe.DirichletBC(
+            W.sub(1), (0.,)*sim.mesh.geometric_dimension(), "on_boundary"),
         fe.DirichletBC(W.sub(2), sim.hot_wall_temperature, 1),
         fe.DirichletBC(W.sub(2), sim.cold_wall_temperature, 2)]
         
@@ -173,25 +174,12 @@ def weak_form_residual(sim, solution):
             sapphire.simulations.enthalpy_porosity.energy,
             sapphire.simulations.enthalpy_porosity.pressure_penalty)])\
         *fe.dx(degree = sim.quadrature_degree)
-    
-    
-def default_mesh(meshsize, spatial_dimensions):
-
-    if spatial_dimensions == 2:
         
-        mesh = fe.UnitSquareMesh(meshsize, meshsize)
         
-    elif spatial_dimensions == 3:
-    
-        mesh = fe.UnitCubeMesh(meshsize, meshsize, meshsize)
-    
-    return mesh    
-    
-    
 class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
 
     def __init__(self, *args,
-            mesh: typing.Union[fe.UnitSquareMesh, fe.UnitCubeMesh],
+            mesh: typing.Union[fe.UnitSquareMesh, fe.UnitCubeMesh] = None,
             reference_temperature_range__degC = 10.,
             cold_wall_temperature_before_freezing = 0.,
             cold_wall_temperature_during_freezing = -1.,
@@ -201,6 +189,10 @@ class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
             heat_capacity_solid_to_liquid_ratio = 0.500,
             thermal_conductivity_solid_to_liquid_ratio = 2.14/0.561,
             **kwargs):
+            
+        if mesh is None:
+        
+            mesh = fe.UnitSquareMesh(24, 24)
         
         self.reference_temperature_range__degC = fe.Constant(
             reference_temperature_range__degC)

--- a/sapphire/simulations/examples/heat_driven_cavity.py
+++ b/sapphire/simulations/examples/heat_driven_cavity.py
@@ -12,7 +12,8 @@ def dirichlet_boundary_conditions(sim):
     W = sim.function_space
     
     return [
-        fe.DirichletBC(W.sub(1), (0., 0.), "on_boundary"),
+        fe.DirichletBC(
+            W.sub(1), (0.,)*sim.mesh.geometric_dimension(), "on_boundary"),
         fe.DirichletBC(W.sub(2), sim.hot_wall_temperature, 1),
         fe.DirichletBC(W.sub(2), sim.cold_wall_temperature, 2)]
         
@@ -26,20 +27,24 @@ default_Gr = default_Ra/default_Pr
 class Simulation(sapphire.simulations.navier_stokes_boussinesq.Simulation):
     
     def __init__(self, *args, 
-            meshsize, 
+            mesh: typing.Union[fe.UnitSquareMesh, fe.UnitCubeMesh] = None,
             hot_wall_temperature = 0.5,
             cold_wall_temperature = -0.5,
             grashof_number = default_Gr,
             prandtl_number = default_Pr,
             **kwargs):
         
+        if mesh is None:
+            
+            mesh = fe.UnitSquareMesh(40, 40)
+            
         self.hot_wall_temperature = fe.Constant(hot_wall_temperature)
     
         self.cold_wall_temperature = fe.Constant(cold_wall_temperature)
         
         super().__init__(
             *args,
-            mesh = fe.UnitSquareMesh(meshsize, meshsize),
+            mesh = mesh,
             initial_values = initial_values,
             dirichlet_boundary_conditions = dirichlet_boundary_conditions,
             grashof_number = grashof_number,

--- a/sapphire/simulations/examples/heat_driven_cavity.py
+++ b/sapphire/simulations/examples/heat_driven_cavity.py
@@ -1,5 +1,6 @@
 import firedrake as fe
 import sapphire.simulations.navier_stokes_boussinesq
+import typing
 
 
 def initial_values(sim):

--- a/sapphire/simulations/examples/lid_driven_cavity.py
+++ b/sapphire/simulations/examples/lid_driven_cavity.py
@@ -1,5 +1,6 @@
 import firedrake as fe
 import sapphire.simulations.navier_stokes
+import typing
 
 
 def initial_values(sim):
@@ -8,7 +9,7 @@ def initial_values(sim):
 
     
 def dirichlet_boundary_conditions(sim):
-        
+    
     W = sim.function_space
     
     return [
@@ -19,14 +20,16 @@ def dirichlet_boundary_conditions(sim):
 class Simulation(sapphire.simulations.navier_stokes.Simulation):
     
     def __init__(self, *args, 
-            horizontal_cellcount, 
-            vertical_cellcount,
+            mesh: fe.UnitSquareMesh = None,
             **kwargs):
         
+        if mesh is None:
+        
+            mesh = fe.UnitSquareMesh(50, 50)
+            
         super().__init__(
             *args,
-            mesh = fe.UnitSquareMesh(
-                horizontal_cellcount, vertical_cellcount),
+            mesh = mesh,
             initial_values = initial_values,
             dirichlet_boundary_conditions = dirichlet_boundary_conditions,
             **kwargs)

--- a/sapphire/simulations/examples/lid_driven_cavity.py
+++ b/sapphire/simulations/examples/lid_driven_cavity.py
@@ -21,6 +21,7 @@ class Simulation(sapphire.simulations.navier_stokes.Simulation):
     
     def __init__(self, *args, 
             mesh: fe.UnitSquareMesh = None,
+            reynolds_number = 100.,
             **kwargs):
         
         if mesh is None:
@@ -30,6 +31,7 @@ class Simulation(sapphire.simulations.navier_stokes.Simulation):
         super().__init__(
             *args,
             mesh = mesh,
+            reynolds_number = reynolds_number,
             initial_values = initial_values,
             dirichlet_boundary_conditions = dirichlet_boundary_conditions,
             **kwargs)

--- a/sapphire/simulations/examples/melt_octadecane.py
+++ b/sapphire/simulations/examples/melt_octadecane.py
@@ -40,7 +40,8 @@ def dirichlet_boundary_conditions(sim):
     W = sim.function_space
     
     return [
-        fe.DirichletBC(W.sub(1), (0., 0.), "on_boundary"),
+        fe.DirichletBC(
+            W.sub(1), (0.,)*sim.mesh.geometric_dimension(), "on_boundary"),
         fe.DirichletBC(W.sub(2), sim.hotwall_temperature, 1),
         fe.DirichletBC(W.sub(2), sim.initial_temperature, 2)]
         
@@ -48,7 +49,7 @@ def dirichlet_boundary_conditions(sim):
 class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
     
     def __init__(self, *args, 
-            meshsize,
+            mesh: typing.Union[fe.UnitSquareMesh, fe.UnitCubeMesh] = None,
             hotwall_temperature = 1.,
             initial_temperature = -0.01, 
             stefan_number = 0.045,
@@ -57,6 +58,10 @@ class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
             liquidus_temperature = 0.,
             **kwargs):
         
+        if mesh is None:
+        
+            mesh = fe.UnitSquareMesh(24, 24)
+            
         self.hotwall_temperature = fe.Constant(hotwall_temperature)
         
         self.initial_temperature = fe.Constant(initial_temperature)
@@ -69,7 +74,7 @@ class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
             stefan_number = stefan_number,
             grashof_number = grashof_number,
             prandtl_number = prandtl_number,
-            mesh = fe.UnitSquareMesh(meshsize, meshsize),
+            mesh = mesh,
             initial_values = initial_values,
             dirichlet_boundary_conditions = dirichlet_boundary_conditions,
             **kwargs)

--- a/sapphire/simulations/examples/melt_octadecane.py
+++ b/sapphire/simulations/examples/melt_octadecane.py
@@ -16,6 +16,7 @@ based on
 """
 import firedrake as fe
 import sapphire.simulations.enthalpy_porosity
+import typing
 
 
 def initial_values(sim):

--- a/tests/regression/test__freeze_water_in_cavity.py
+++ b/tests/regression/test__freeze_water_in_cavity.py
@@ -5,7 +5,6 @@ import sapphire.test
 
 tempdir = sapphire.test.datadir
 
-
 def test__validate__freeze_water__regression(tempdir):
     
     endtime = 1.44

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -8,7 +8,7 @@ def test__validate__melt_octadecane__regression(tempdir):
     
     sim = sapphire.simulations.examples.melt_octadecane.Simulation(
         element_degree = (1, 1, 1),
-        meshsize = 24,
+        mesh = fe.UnitSquareMesh(24, 24),
         quadrature_degree = 4,
         time_stencil_size = 3,
         timestep_size = 20.,

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -1,3 +1,4 @@
+import firedrake as fe
 import sapphire.simulations.examples.melt_octadecane
 import sapphire.test
 

--- a/tests/validation/test__heat_driven_cavity.py
+++ b/tests/validation/test__heat_driven_cavity.py
@@ -22,7 +22,7 @@ import sapphire.test
 def test__validate_heat_driven_cavity_benchmark():
 
     sim = sapphire.simulations.examples.heat_driven_cavity.Simulation(
-        element_degree = (1, 2, 2), meshsize = 40)
+        element_degree = (1, 2, 2), mesh = fe.UnitSquareMesh(40, 40))
     
     sim.solution = sim.solve()
     

--- a/tests/validation/test__lid_driven_cavity.py
+++ b/tests/validation/test__lid_driven_cavity.py
@@ -21,8 +21,7 @@ def test__lid_driven_cavity_benchmark():
     
     sim = sapphire.simulations.examples.lid_driven_cavity.Simulation(
         reynolds_number = 100.,
-        horizontal_cellcount = 50,
-        vertical_cellcount = 50,
+        fe.UnitSquareMesh(50, 50),
         element_degree = (2, 1))
     
     sim.solution = sim.solve()

--- a/tests/validation/test__lid_driven_cavity.py
+++ b/tests/validation/test__lid_driven_cavity.py
@@ -21,7 +21,7 @@ def test__lid_driven_cavity_benchmark():
     
     sim = sapphire.simulations.examples.lid_driven_cavity.Simulation(
         reynolds_number = 100.,
-        fe.UnitSquareMesh(50, 50),
+        mesh = fe.UnitSquareMesh(50, 50),
         element_degree = (2, 1))
     
     sim.solution = sim.solve()


### PR DESCRIPTION
Sapphire's subpackages are organized now such that all `Simulation` classes from modules in `sapphire/simulations/examples` should have `__init__` constructors without any required arguments.