### PR TITLE
Remove pressure penalty, instead using nullspace and enforcing zero mean pressure

### DIFF
--- a/sapphire/continuation.py
+++ b/sapphire/continuation.py
@@ -10,7 +10,7 @@ def solve_with_over_regularization(
         solution,
         regularization_parameter,
         search_operator = lambda r: 2.*r,
-        attempts = 16,
+        attempts = 24,
         startval = None):
     
     original_regularization_parameter_value = \
@@ -61,7 +61,7 @@ def solve_with_bounded_regularization_sequence(
         backup_solution,
         regularization_parameter,
         initial_regularization_sequence,
-        maxcount = 16):
+        maxcount = 24):
     """ Solve a strongly nonlinear problem 
     by solving a sequence of over-regularized problems 
     with successively reduced regularization.

--- a/sapphire/continuation.py
+++ b/sapphire/continuation.py
@@ -96,7 +96,7 @@ def solve_with_bounded_regularization_sequence(
                 
                 backup_solution = backup_solution.assign(solution)
                 
-                print("Solved with regularization parameter = {}".format(r))
+                print("Solved with continuation parameter = {}".format(r))
                 
             solved = True
             
@@ -108,7 +108,7 @@ def solve_with_bounded_regularization_sequence(
             
             rs = regularization_sequence
         
-            print("Failed to solve with regularization paramter = {}"
+            print("Failed to solve with continuation parameter = {}"
                   " from the sequence {}".format(current_r, rs))
                 
             index = rs.index(current_r)

--- a/sapphire/continuation.py
+++ b/sapphire/continuation.py
@@ -102,7 +102,7 @@ def solve_with_bounded_regularization_sequence(
             
             break
             
-        except fe.exceptions.ConvergenceError as exception:  
+        except fe.exceptions.ConvergenceError as exception:
             
             current_r = regularization_parameter.__float__()
             

--- a/sapphire/continuation.py
+++ b/sapphire/continuation.py
@@ -34,7 +34,7 @@ def solve_with_over_regularization(
         
         regularization_parameter = regularization_parameter.assign(r)
         
-        print("Trying r = {0}".format(r))
+        print("Trying r = {}".format(r))
         
         try:
             
@@ -96,7 +96,7 @@ def solve_with_bounded_regularization_sequence(
                 
                 backup_solution = backup_solution.assign(solution)
                 
-                print("Solved with regularization parameter = {0}".format(r))
+                print("Solved with regularization parameter = {}".format(r))
                 
             solved = True
             
@@ -104,12 +104,14 @@ def solve_with_bounded_regularization_sequence(
             
         except fe.exceptions.ConvergenceError as exception:  
             
+            solution = solution.assign(backup_solution)
+            
             current_r = regularization_parameter.__float__()
             
             rs = regularization_sequence
         
-            print("Failed to solve with regularization paramter = {0} \
-                from the sequence {1}".format(current_r, rs))
+            print("Failed to solve with regularization paramter = {}"
+                  " from the sequence {}".format(current_r, rs))
                 
             index = rs.index(current_r)
             
@@ -122,8 +124,6 @@ def solve_with_bounded_regularization_sequence(
             r_to_insert = (current_r + rs[index - 1])/2.
             
             new_rs = rs[:index] + (r_to_insert,) + rs[index:]
-            
-            solution = solution.assign(backup_solution)
             
             regularization_sequence = new_rs
             

--- a/sapphire/continuation.py
+++ b/sapphire/continuation.py
@@ -104,8 +104,6 @@ def solve_with_bounded_regularization_sequence(
             
         except fe.exceptions.ConvergenceError as exception:  
             
-            solution = solution.assign(backup_solution)
-            
             current_r = regularization_parameter.__float__()
             
             rs = regularization_sequence
@@ -120,7 +118,9 @@ def solve_with_bounded_regularization_sequence(
                 regularization_parameter = regularization_parameter.assign(r0)
                 
                 raise(exception)
-                
+            
+            solution = solution.assign(backup_solution)
+            
             r_to_insert = (current_r + rs[index - 1])/2.
             
             new_rs = rs[:index] + (r_to_insert,) + rs[index:]

--- a/sapphire/output.py
+++ b/sapphire/output.py
@@ -17,14 +17,14 @@ def write_solution(sim,
     if solution is None:
     
         solution = sim.solution
-        
+    
     if time is None:
     
         time = sim.time
-        
+    
     if file is None:
     
-        time = sim.solution_file
+        file = sim.solution_file
         
     functions_to_write = solution.split()
     
@@ -33,15 +33,19 @@ def write_solution(sim,
         if hasattr(sim, "postprocessed_functions"):
         
             dependent_functions = sim.postprocessed_functions
-        
+    
     if dependent_functions is not None:
     
         functions_to_write += dependent_functions
-        
+    
+    
+    print("Writing solution to {}".format(file.filename))
+    
+    
     if time is None:
         
         file.write(functions_to_write)
-        
+    
     else:
     
         if type(time) is type(0.):
@@ -51,8 +55,8 @@ def write_solution(sim,
         elif type(time) is fe.Constant:
         
             timefloat = time.__float__()
-            
-        file.write(*functions_to_write, time = timefloat)
+
+    file.write(*functions_to_write, time = timefloat)
     
     
 def writeplots(

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -141,13 +141,19 @@ def time_discrete_terms(sim):
 
 def mass(sim, solution):
     
-    _, u, _ = fe.split(solution)
+    p, u, T = fe.split(solution)
     
     psi_p, _, _ = fe.TestFunctions(solution.function_space())
     
+    phi_l = liquid_volume_fraction(sim = sim, temperature = T)
+    
+    phi_s = 1. - phi_l
+    
+    gamma_s = sim.solid_pressure_penalty
+    
     div = fe.div
     
-    mass = psi_p*div(u)
+    mass = psi_p*(div(u) + gamma_s*phi_s*p)
     
     return mass
     
@@ -234,6 +240,7 @@ class Simulation(sapphire.simulation.Simulation):
             heat_capacity_solid_to_liquid_ratio = 1.,
             thermal_conductivity_solid_to_liquid_ratio = 1.,
             solid_velocity_relaxation_factor = 1.e-12,
+            solid_pressure_penalty = 1.e-5,
             liquidus_smoothing_factor = 0.01,
             solver_parameters = default_solver_parameters,
             **kwargs):
@@ -257,6 +264,9 @@ class Simulation(sapphire.simulation.Simulation):
         
         self.solid_velocity_relaxation_factor = fe.Constant(
             solid_velocity_relaxation_factor)
+        
+        self.solid_pressure_penalty = fe.Constant(
+            solid_pressure_penalty)
         
         self.liquidus_smoothing_factor = fe.Constant(
             liquidus_smoothing_factor)

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -226,7 +226,7 @@ default_solver_parameters =  {
     "mat_type": "aij"}
 
 
-def nullspace(sim):
+def default_nullspace(sim):
     """Inform solver that pressure solution is not unique.
     
     It is only defined up to adding an arbitrary constant.
@@ -256,6 +256,7 @@ class Simulation(sapphire.simulation.Simulation):
             solid_pressure_penalty = 0.,
             liquidus_smoothing_factor = 0.01,
             solver_parameters = default_solver_parameters,
+            nullspace = default_nullspace,
             **kwargs):
             
         self.grashof_number = fe.Constant(grashof_number)

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -225,6 +225,18 @@ default_solver_parameters =  {
     "pc_factor_mat_solver_type": "mumps",
     "mat_type": "aij"}
 
+
+def nullspace(sim):
+    """Inform solver that pressure solution is not unique.
+    
+    It is only defined up to adding an arbitrary constant.
+    """
+    W = sim.function_space
+    
+    return fe.MixedVectorSpaceBasis(
+        W, [fe.VectorSpaceBasis(constant=True), W.sub(1), W.sub(2)])
+
+
 class Simulation(sapphire.simulation.Simulation):
     
     def __init__(
@@ -241,7 +253,7 @@ class Simulation(sapphire.simulation.Simulation):
             thermal_conductivity_solid_to_liquid_ratio = 1.,
             solid_velocity_relaxation_factor = 1.e-12,
             liquid_pressure_penalty = 0.,
-            solid_pressure_penalty = 1.e-4,
+            solid_pressure_penalty = 0.,
             liquidus_smoothing_factor = 0.01,
             solver_parameters = default_solver_parameters,
             **kwargs):
@@ -290,6 +302,7 @@ class Simulation(sapphire.simulation.Simulation):
             element = element(
                 cell = mesh.ufl_cell(), degree = element_degree),
             solver_parameters = solver_parameters,
+            nullspace = nullspace,
             **kwargs)
             
     def solve(self) -> fe.Function:

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -240,7 +240,7 @@ class Simulation(sapphire.simulation.Simulation):
             heat_capacity_solid_to_liquid_ratio = 1.,
             thermal_conductivity_solid_to_liquid_ratio = 1.,
             solid_velocity_relaxation_factor = 1.e-12,
-            solid_pressure_penalty = 1.e-5,
+            solid_pressure_penalty = 1.e-4,
             liquidus_smoothing_factor = 0.01,
             solver_parameters = default_solver_parameters,
             **kwargs):

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -353,6 +353,8 @@ class Simulation(sapphire.simulation.Simulation):
                 # This is sometimes useful after solving some time steps
                 # with a previously successful regularization sequence
                 # that is not working for a new time step.
+                self.solution = self.solution.assign(self.solutions[1])
+                
                 self.solution, smax = self.solve_with_over_regularization()
                 
                 self.smoothing_sequence = (smax, sigma)

--- a/sapphire/simulations/enthalpy_porosity.py
+++ b/sapphire/simulations/enthalpy_porosity.py
@@ -147,13 +147,13 @@ def mass(sim, solution):
     
     phi_l = liquid_volume_fraction(sim = sim, temperature = T)
     
-    phi_s = 1. - phi_l
+    gamma_l = sim.liquid_pressure_penalty
     
     gamma_s = sim.solid_pressure_penalty
     
     div = fe.div
     
-    mass = psi_p*(div(u) + gamma_s*phi_s*p)
+    mass = psi_p*(div(u) + (gamma_l*phi_l + gamma_s*(1. - phi_l))*p)
     
     return mass
     
@@ -240,6 +240,7 @@ class Simulation(sapphire.simulation.Simulation):
             heat_capacity_solid_to_liquid_ratio = 1.,
             thermal_conductivity_solid_to_liquid_ratio = 1.,
             solid_velocity_relaxation_factor = 1.e-12,
+            liquid_pressure_penalty = 0.,
             solid_pressure_penalty = 1.e-4,
             liquidus_smoothing_factor = 0.01,
             solver_parameters = default_solver_parameters,
@@ -265,6 +266,9 @@ class Simulation(sapphire.simulation.Simulation):
         self.solid_velocity_relaxation_factor = fe.Constant(
             solid_velocity_relaxation_factor)
         
+        self.liquid_pressure_penalty = fe.Constant(
+            liquid_pressure_penalty)
+            
         self.solid_pressure_penalty = fe.Constant(
             solid_pressure_penalty)
         

--- a/sapphire/simulations/examples/freeze_water_in_cavity.py
+++ b/sapphire/simulations/examples/freeze_water_in_cavity.py
@@ -58,28 +58,25 @@ def water_buoyancy(sim, temperature):
     
 def heat_driven_cavity_weak_form_residual(sim, solution):
     
-    mass = sapphire.simulations.enthalpy_porosity.mass(sim, solution)
-    
-    pressure_penalty = sapphire.simulations.enthalpy_porosity.\
-        pressure_penalty(sim, solution)
-    
     p, u, T = fe.split(solution)
     
     b = water_buoyancy(sim = sim, temperature = T)
     
     Pr = sim.prandtl_number
     
-    _, psi_u, psi_T = fe.TestFunctions(sim.function_space)
+    psi_p, psi_u, psi_T = fe.TestFunctions(sim.function_space)
     
     inner, dot, grad, div, sym = \
         fe.inner, fe.dot, fe.grad, fe.div, fe.sym
-        
+    
+    mass = psi_p*div(u)
+    
     momentum = dot(psi_u, grad(u)*u + b) \
         - div(psi_u)*p + 2.*inner(sym(grad(psi_u)), sym(grad(u)))
     
     energy = psi_T*dot(u, grad(T)) + dot(grad(psi_T), 1./Pr*grad(T))
     
-    return mass + momentum + energy + pressure_penalty
+    return mass + momentum + energy
     
     
 def dirichlet_boundary_conditions(sim):
@@ -97,17 +94,7 @@ def initial_values(sim):
     
     print("Solving steady heat driven cavity to obtain initial values")
     
-    Ra = 2.518084e6
-
-    Pr = 6.99
-
-    sim.grashof_number = sim.grashof_number.assign(Ra/Pr)
-    
-    sim.prandtl_number = sim.prandtl_number.assign(Pr)
-    
-    w = fe.Function(sim.function_space)
-    
-    p, u, T = w.split()
+    p, u, T = sim.solution.split()
     
     p.assign(0.)
     
@@ -123,13 +110,13 @@ def initial_values(sim):
     
     F = heat_driven_cavity_weak_form_residual(
         sim = sim,
-        solution = w)*fe.dx(degree = sim.quadrature_degree)
+        solution = sim.solution)*fe.dx(degree = sim.quadrature_degree)
         
     problem = fe.NonlinearVariationalProblem(
         F = F,
-        u = w,
+        u = sim.solution,
         bcs = dirichlet_boundary_conditions(sim),
-        J = fe.derivative(F, w))
+        J = fe.derivative(F, sim.solution))
     
     solver = fe.NonlinearVariationalSolver(
         problem = problem,
@@ -146,18 +133,26 @@ def initial_values(sim):
     
         solver.solve()
         
-        return w
+        p, _, _ = sim.solution.split()
+        
+        dx = fe.dx(degree = sim.quadrature_degree)
+        
+        mean_pressure = fe.assemble(p*dx)
+        
+        p = p.assign(p - mean_pressure)
+        
+        return sim.solution
     
-    w, _ = \
+    sim.solution, _ = \
         sapphire.continuation.solve_with_bounded_regularization_sequence(
             solve = solve,
-            solution = w,
-            backup_solution = fe.Function(w),
+            solution = sim.solution,
+            backup_solution = fe.Function(sim.solution),
             regularization_parameter = sim.grashof_number,
             initial_regularization_sequence = (
                 0., sim.grashof_number.__float__()))
                 
-    return w
+    return sim.solution
 
     
 def weak_form_residual(sim, solution):
@@ -171,8 +166,7 @@ def weak_form_residual(sim, solution):
                     sim = sim,
                     solution = solution,
                     buoyancy = water_buoyancy),
-            sapphire.simulations.enthalpy_porosity.energy,
-            sapphire.simulations.enthalpy_porosity.pressure_penalty)])\
+            sapphire.simulations.enthalpy_porosity.energy)])\
         *fe.dx(degree = sim.quadrature_degree)
         
         
@@ -183,6 +177,8 @@ class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
             reference_temperature_range__degC = 10.,
             cold_wall_temperature_before_freezing = 0.,
             cold_wall_temperature_during_freezing = -1.,
+            rayleigh_number = 2.518084e6,
+            prandtl_number = 6.99,
             stefan_number = 0.125,
             liquidus_temperature = 0.,
             density_solid_to_liquid_ratio = 916.70/999.84,
@@ -207,6 +203,8 @@ class Simulation(sapphire.simulations.enthalpy_porosity.Simulation):
             weak_form_residual = weak_form_residual,
             initial_values = initial_values,
             dirichlet_boundary_conditions = dirichlet_boundary_conditions,
+            grashof_number = rayleigh_number/prandtl_number,
+            prandtl_number = prandtl_number,
             stefan_number = stefan_number,
             liquidus_temperature = liquidus_temperature,
             density_solid_to_liquid_ratio = density_solid_to_liquid_ratio,

--- a/sapphire/simulations/examples/freeze_water_in_cavity.py
+++ b/sapphire/simulations/examples/freeze_water_in_cavity.py
@@ -64,8 +64,6 @@ def heat_driven_cavity_weak_form_residual(sim, solution):
     
     Pr = sim.prandtl_number
     
-    gamma_l = sim.liquid_pressure_penalty
-    
     psi_p, psi_u, psi_T = fe.TestFunctions(sim.function_space)
     
     inner, dot, grad, div, sym = \
@@ -78,9 +76,7 @@ def heat_driven_cavity_weak_form_residual(sim, solution):
     
     energy = psi_T*dot(u, grad(T)) + dot(grad(psi_T), 1./Pr*grad(T))
     
-    pressure_penalty = psi_p*gamma_l*p
-    
-    return mass + momentum + energy + pressure_penalty
+    return mass + momentum + energy
     
     
 def dirichlet_boundary_conditions(sim):
@@ -137,16 +133,14 @@ def initial_values(sim):
     
         solver.solve()
         
-        if sim.enforce_zero_mean_pressure:
-            
-            p, _, _ = sim.solution.split()
-            
-            dx = fe.dx(degree = sim.quadrature_degree)
-            
-            mean_pressure = fe.assemble(p*dx)
-            
-            p = p.assign(p - mean_pressure)
-            
+        p, _, _ = sim.solution.split()
+        
+        dx = fe.dx(degree = sim.quadrature_degree)
+        
+        mean_pressure = fe.assemble(p*dx)
+        
+        p = p.assign(p - mean_pressure)
+        
         return sim.solution
     
     sim.solution, _ = \

--- a/sapphire/simulations/navier_stokes.py
+++ b/sapphire/simulations/navier_stokes.py
@@ -3,11 +3,10 @@
 This can be used to simulate incompressible flow,
 e.g. the lid-driven cavity.
 
+Dirichlet BC's should not be placed on the pressure.
 The returned pressure solution will always have zero mean.
 
-Neumann BC's are not implemented.
-
-Dirichlet BC's should not be placed on the pressure.
+Non-homogeneous Neumann BC's are not implemented for the velocity.
 """
 import firedrake as fe
 import sapphire.simulation

--- a/sapphire/simulations/navier_stokes.py
+++ b/sapphire/simulations/navier_stokes.py
@@ -54,7 +54,10 @@ def strong_residual(sim, solution):
     
     
 def nullspace(sim):
-    """Inform solver that pressure is only defined up to a constant."""
+    """Inform solver that pressure solution is not unique.
+    
+    It is only defined up to adding an arbitrary constant.
+    """
     W = sim.function_space
     
     return fe.MixedVectorSpaceBasis(

--- a/sapphire/simulations/navier_stokes_boussinesq.py
+++ b/sapphire/simulations/navier_stokes_boussinesq.py
@@ -24,8 +24,8 @@ def linear_boussinesq_buoyancy(sim, temperature):
     
     
 inner, dot, grad, div, sym = \
-        fe.inner, fe.dot, fe.grad, fe.div, fe.sym
-        
+    fe.inner, fe.dot, fe.grad, fe.div, fe.sym
+    
 def weak_form_residual(
         sim, solution, buoyancy = linear_boussinesq_buoyancy):
     

--- a/sapphire/simulations/navier_stokes_boussinesq.py
+++ b/sapphire/simulations/navier_stokes_boussinesq.py
@@ -83,7 +83,10 @@ def element(cell, degree):
 
 
 def nullspace(sim):
-    """Inform solver that pressure is only defined up to a constant."""
+    """Inform solver that pressure solution is not unique.
+    
+    It is only defined up to adding an arbitrary constant.
+    """
     W = sim.function_space
     
     return fe.MixedVectorSpaceBasis(

--- a/sapphire/simulations/navier_stokes_boussinesq.py
+++ b/sapphire/simulations/navier_stokes_boussinesq.py
@@ -5,6 +5,8 @@ e.g the heat-driven cavity.
 
 Dirichlet BC's should not be placed on the pressure.
 The returned pressure solution will always have zero mean.
+
+Non-homogeneous Neumann BC's are not implemented for the velocity.
 """
 import firedrake as fe
 import sapphire.simulation

--- a/sapphire/simulations/navier_stokes_boussinesq.py
+++ b/sapphire/simulations/navier_stokes_boussinesq.py
@@ -81,6 +81,14 @@ def element(cell, degree):
     return fe.MixedElement(
         pressure_element, velocity_element, temperature_element)
 
+
+def nullspace(sim):
+    """Inform solver that pressure is only defined up to a constant."""
+    W = sim.function_space
+    
+    return fe.MixedVectorSpaceBasis(
+        W, [fe.VectorSpaceBasis(constant=True), W.sub(1), W.sub(2)])
+
     
 class Simulation(sapphire.simulation.Simulation):
     
@@ -101,6 +109,7 @@ class Simulation(sapphire.simulation.Simulation):
                 cell = mesh.ufl_cell(), degree = element_degree),
             weak_form_residual = weak_form_residual,
             time_stencil_size = 1,
+            nullspace = nullspace,
             **kwargs)
             
     def solve(self) -> fe.Function:

--- a/sapphire/simulations/unsteady_navier_stokes.py
+++ b/sapphire/simulations/unsteady_navier_stokes.py
@@ -3,11 +3,10 @@
 This can be used to simulate incompressible flow,
 e.g. the lid-driven cavity.
 
+Dirichlet BC's should not be placed on the pressure.
 The returned pressure solution will always have zero mean.
 
-Neumann BC's are not implemented.
-
-Dirichlet BC's should not be placed on the pressure.
+Non-homogeneous Neumann BC's are not implemented for the velocity.
 """
 import firedrake as fe
 import sapphire.simulation

--- a/sapphire/simulations/unsteady_navier_stokes.py
+++ b/sapphire/simulations/unsteady_navier_stokes.py
@@ -64,7 +64,10 @@ def strong_residual(sim, solution):
 
 
 def nullspace(sim):
-    """Inform solver that pressure is only defined up to a constant."""
+    """Inform solver that pressure solution is not unique.
+    
+    It is only defined up to adding an arbitrary constant.
+    """
     W = sim.function_space
     
     return fe.MixedVectorSpaceBasis(

--- a/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
+++ b/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
@@ -2,6 +2,11 @@
 
 This can be used to simulate natural convection,
 e.g the heat-driven cavity.
+
+Dirichlet BC's should not be placed on the pressure.
+The returned pressure solution will always have zero mean.
+
+Non-homogeneous Neumann BC's are not implemented for the velocity.
 """
 import firedrake as fe
 import sapphire.simulation
@@ -18,8 +23,8 @@ def linear_boussinesq_buoyancy(sim, temperature):
     return Gr*T*ghat
     
     
-_,       diff,    inner,    dot,    grad,    div,    sym = \
-None, fe.diff, fe.inner, fe.dot, fe.grad, fe.div, fe.sym
+diff, inner, dot, grad, div, sym = \
+    fe.diff, fe.inner, fe.dot, fe.grad, fe.div, fe.sym
     
 def weak_form_residual(
         sim, solution, buoyancy = linear_boussinesq_buoyancy):

--- a/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
+++ b/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
@@ -83,6 +83,14 @@ def element(cell, degree):
     return fe.MixedElement(
         pressure_element, velocity_element, temperature_element)
 
+
+def nullspace(sim):
+    """Inform solver that pressure is only defined up to a constant."""
+    W = sim.function_space
+    
+    return fe.MixedVectorSpaceBasis(
+        W, [fe.VectorSpaceBasis(constant=True), W.sub(1), W.sub(2)])
+
     
 class Simulation(sapphire.simulation.Simulation):
     
@@ -102,6 +110,7 @@ class Simulation(sapphire.simulation.Simulation):
             element = element(
                 cell = mesh.ufl_cell(), degree = element_degree),
             weak_form_residual = weak_form_residual,
+            nullspace = nullspace,
             **kwargs)
             
     def solve(self) -> fe.Function:

--- a/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
+++ b/sapphire/simulations/unsteady_navier_stokes_boussinesq.py
@@ -85,7 +85,10 @@ def element(cell, degree):
 
 
 def nullspace(sim):
-    """Inform solver that pressure is only defined up to a constant."""
+    """Inform solver that pressure solution is not unique.
+    
+    It is only defined up to adding an arbitrary constant.
+    """
     W = sim.function_space
     
     return fe.MixedVectorSpaceBasis(

--- a/tests/regression/test__freeze_water_in_cavity.py
+++ b/tests/regression/test__freeze_water_in_cavity.py
@@ -16,13 +16,6 @@ def test__validate__freeze_water__regression(tempdir):
         time_stencil_size = 3,
         timestep_size = endtime/4.,
         solid_velocity_relaxation_factor = 1.e-12,
-        #liquid_pressure_penalty = 1.e-7,
-        #solid_pressure_penalty = 1.e-7,
-        #nullspace = None,
-        #enforce_zero_mean_pressure = False,
-        liquid_pressure_penalty = 0.,
-        solid_pressure_penalty = 0.,
-        enforce_zero_mean_pressure = True,
         liquidus_smoothing_factor = 0.005,
         output_directory_path = tempdir)
     
@@ -31,36 +24,4 @@ def test__validate__freeze_water__regression(tempdir):
     print("Liquid area = {}".format(sim.liquid_area))
     
     assert(abs(sim.liquid_area - 0.69) < 0.01)
-    
-    
-def test__validate__freeze_water_3d__regression(tempdir):
-    
-    X = 0.038  # m
-
-    nu_l = 1.0032e-6  # m^2/s
-
-    timescale = X**2/nu_l
-    
-    target_time = 2340.  # s
-    
-    nondimensional_target_time = target_time/timescale
-    
-    sim = sapphire.simulations.examples.freeze_water_in_cavity.Simulation(
-        element_degree = (1, 1, 1),
-        mesh = fe.UnitCubeMesh(8, 8, 8),
-        quadrature_degree = 2,
-        time_stencil_size = 3,
-        timestep_size = nondimensional_target_time/2.,
-        solid_velocity_relaxation_factor = 1.e-8,
-        liquid_pressure_penalty = 1.e-7,
-        solid_pressure_penalty = 1.e-7,
-        nullspace = None,
-        liquidus_smoothing_factor = 0.01,
-        output_directory_path = tempdir)
-    
-    sim.run(endtime = nondimensional_target_time)
-    
-    print("Liquid area = {}".format(sim.liquid_area))
-    
-    assert(abs(sim.liquid_area - 0.67) < 0.01)
     

--- a/tests/regression/test__freeze_water_in_cavity.py
+++ b/tests/regression/test__freeze_water_in_cavity.py
@@ -16,7 +16,11 @@ def test__validate__freeze_water__regression(tempdir):
         time_stencil_size = 3,
         timestep_size = endtime/4.,
         solid_velocity_relaxation_factor = 1.e-12,
-        liquidus_smoothing_factor = 1./200.,
+        liquid_pressure_penalty = 1.e-7,
+        solid_pressure_penalty = 1.e-7,
+        nullspace = None,
+        enforce_zero_mean_pressure = False,
+        liquidus_smoothing_factor = 0.005,
         output_directory_path = tempdir)
     
     sim.run(endtime = endtime, plot = True)
@@ -45,7 +49,9 @@ def test__validate__freeze_water_3d__regression(tempdir):
         time_stencil_size = 3,
         timestep_size = nondimensional_target_time/2.,
         solid_velocity_relaxation_factor = 1.e-8,
-        pressure_penalty_factor = 1.e-7,
+        liquid_pressure_penalty = 1.e-7,
+        solid_pressure_penalty = 1.e-7,
+        nullspace = None,
         liquidus_smoothing_factor = 0.01,
         output_directory_path = tempdir)
     

--- a/tests/regression/test__freeze_water_in_cavity.py
+++ b/tests/regression/test__freeze_water_in_cavity.py
@@ -16,10 +16,13 @@ def test__validate__freeze_water__regression(tempdir):
         time_stencil_size = 3,
         timestep_size = endtime/4.,
         solid_velocity_relaxation_factor = 1.e-12,
-        liquid_pressure_penalty = 1.e-7,
-        solid_pressure_penalty = 1.e-7,
-        nullspace = None,
-        enforce_zero_mean_pressure = False,
+        #liquid_pressure_penalty = 1.e-7,
+        #solid_pressure_penalty = 1.e-7,
+        #nullspace = None,
+        #enforce_zero_mean_pressure = False,
+        liquid_pressure_penalty = 0.,
+        solid_pressure_penalty = 0.,
+        enforce_zero_mean_pressure = True,
         liquidus_smoothing_factor = 0.005,
         output_directory_path = tempdir)
     

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -21,7 +21,7 @@ def test__validate__melt_octadecane__regression(tempdir):
         liquidus_smoothing_factor = 0.005,
         solid_velocity_relaxation_factor = 1.e-12,
         liquid_pressure_penalty = 0.,
-        solid_pressure_penalty = 1.e-4,
+        solid_pressure_penalty = 0.,
         solver_parameters = solver_parameters,
         output_directory_path = tempdir)
     

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -7,14 +7,20 @@ tempdir = sapphire.test.datadir
 
 def test__validate__melt_octadecane__regression(tempdir):
     
+    solver_parameters = sapphire.simulations.enthalpy_porosity.\
+        default_solver_parameters
+        
+    solver_parameters["snes_linesearch_damping"] = 1.
+    
     sim = sapphire.simulations.examples.melt_octadecane.Simulation(
-        element_degree = (1, 1, 1),
+        element_degree = (1, 2, 2),
         mesh = fe.UnitSquareMesh(24, 24),
         quadrature_degree = 4,
         time_stencil_size = 3,
-        timestep_size = 20.,
-        liquidus_smoothing_factor = 1./200.,
-        solid_velocity_relaxation_factor = 1.e-12,
+        timestep_size = 10.,
+        liquidus_smoothing_factor = 0.1,
+        solid_velocity_relaxation_factor = 1.e-10,
+        solver_parameters = solver_parameters,
         output_directory_path = tempdir)
     
     sim.run(endtime = 80.)
@@ -22,4 +28,4 @@ def test__validate__melt_octadecane__regression(tempdir):
     print("Liquid area = {}".format(sim.liquid_area))
     
     assert(abs(sim.liquid_area - 0.41) < 0.01)
-  
+    

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -17,8 +17,8 @@ def test__validate__melt_octadecane__regression(tempdir):
         mesh = fe.UnitSquareMesh(24, 24),
         quadrature_degree = 4,
         time_stencil_size = 3,
-        timestep_size = 10.,
-        liquidus_smoothing_factor = 0.1,
+        timestep_size = 5.,
+        liquidus_smoothing_factor = 0.05,
         solid_velocity_relaxation_factor = 1.e-10,
         solver_parameters = solver_parameters,
         output_directory_path = tempdir)

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -15,8 +15,6 @@ def test__validate__melt_octadecane__regression(tempdir):
         timestep_size = 20.,
         liquidus_smoothing_factor = 0.005,
         solid_velocity_relaxation_factor = 1.e-12,
-        liquid_pressure_penalty = 0.,
-        solid_pressure_penalty = 0.,
         output_directory_path = tempdir)
     
     sim.run(endtime = 80.)

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -13,13 +13,14 @@ def test__validate__melt_octadecane__regression(tempdir):
     solver_parameters["snes_linesearch_damping"] = 1.
     
     sim = sapphire.simulations.examples.melt_octadecane.Simulation(
-        element_degree = (1, 2, 2),
+        element_degree = (1, 2, 1),
         mesh = fe.UnitSquareMesh(24, 24),
         quadrature_degree = 4,
         time_stencil_size = 3,
-        timestep_size = 5.,
-        liquidus_smoothing_factor = 0.05,
-        solid_velocity_relaxation_factor = 1.e-10,
+        timestep_size = 20.,
+        liquidus_smoothing_factor = 0.005,
+        solid_velocity_relaxation_factor = 1.e-12,
+        solid_pressure_penalty = 1.e-4,
         solver_parameters = solver_parameters,
         output_directory_path = tempdir)
     
@@ -27,5 +28,5 @@ def test__validate__melt_octadecane__regression(tempdir):
     
     print("Liquid area = {}".format(sim.liquid_area))
     
-    assert(abs(sim.liquid_area - 0.41) < 0.01)
+    assert(abs(sim.liquid_area - 0.47) < 0.01)
     

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -7,11 +7,6 @@ tempdir = sapphire.test.datadir
 
 def test__validate__melt_octadecane__regression(tempdir):
     
-    solver_parameters = sapphire.simulations.enthalpy_porosity.\
-        default_solver_parameters
-        
-    solver_parameters["snes_linesearch_damping"] = 1.
-    
     sim = sapphire.simulations.examples.melt_octadecane.Simulation(
         element_degree = (1, 2, 1),
         mesh = fe.UnitSquareMesh(24, 24),
@@ -22,7 +17,6 @@ def test__validate__melt_octadecane__regression(tempdir):
         solid_velocity_relaxation_factor = 1.e-12,
         liquid_pressure_penalty = 0.,
         solid_pressure_penalty = 0.,
-        solver_parameters = solver_parameters,
         output_directory_path = tempdir)
     
     sim.run(endtime = 80.)

--- a/tests/regression/test__melt_octadecane.py
+++ b/tests/regression/test__melt_octadecane.py
@@ -20,6 +20,7 @@ def test__validate__melt_octadecane__regression(tempdir):
         timestep_size = 20.,
         liquidus_smoothing_factor = 0.005,
         solid_velocity_relaxation_factor = 1.e-12,
+        liquid_pressure_penalty = 0.,
         solid_pressure_penalty = 1.e-4,
         solver_parameters = solver_parameters,
         output_directory_path = tempdir)

--- a/tests/verification/test__enthalpy_porosity.py
+++ b/tests/verification/test__enthalpy_porosity.py
@@ -1,8 +1,6 @@
 """Verify accuracy of the enthalpy-porosity solver
 
 for convection-coupled phase-change.
-
-The pressure accuracy is not verified.
 """
 import sys
 import pathlib
@@ -27,12 +25,13 @@ def space_verification_solution(sim):
     u = exp(0.5)*sin(2.*pi*x)*sin(pi*y)*ihat + \
         exp(0.5)*sin(pi*x)*sin(2.*pi*y)*jhat
     
-    # The pressure derivative is zero at x = 0, 1 and y = 0, 1
-    # so that Dirichlet BC's do not have to be applied
-    # and non-homogeneous Neumann BC's don't need to be handled.
     p = -sin(pi*x - pi/2.)*sin(2.*pi*y - pi/2.)
     
     T = 0.5*sin(2.*pi*x)*sin(pi*y)*(1. - exp(-0.5))
+    
+    mean_pressure = fe.assemble(p*fe.dx)
+    
+    p -= mean_pressure
     
     return p, u, T
     
@@ -48,12 +47,13 @@ def time_verification_solution(sim):
     u = exp(t/2)*sin(2.*pi*x)*sin(pi*y)*ihat + \
         exp(t/2)*sin(pi*x)*sin(2.*pi*y)*jhat
     
-    # The pressure derivative is zero at x = 0, 1 and y = 0, 1
-    # so that Dirichlet BC's do not have to be applied
-    # and non-homogeneous Neumann BC's don't need to be handled.
     p = -sin(pi*x - pi/2.)*sin(2.*pi*y - pi/2.)
     
     T = 0.5*sin(2.*pi*x)*sin(pi*y)*(1. - exp(-0.5*t**2))
+    
+    mean_pressure = fe.assemble(p*fe.dx)
+    
+    p -= mean_pressure
     
     return p, u, T
     
@@ -67,9 +67,6 @@ sim_kwargs = {
     "thermal_conductivity_solid_to_liquid_ratio": 3.8,
     "liquidus_smoothing_factor": 0.1,
     "solid_velocity_relaxation_factor": 1.e-12,
-    "pressure_penalty_factor": 1.e-4,
-    "quadrature_degree": None,
-    "element_degree": None,
     }
 
 
@@ -95,9 +92,9 @@ def test__verify__second_order_spatial_convergence__via_mms(
             sim_module = sim_module,
             sim_kwargs = sim_kwargs,
             manufactured_solution = space_verification_solution,
-            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32, 64)],
-            norms = (None, "H1", "H1"),
-            expected_orders = (None, 2, 2),
+            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16)],
+            norms = ("L2", "H1", "H1"),
+            expected_orders = (2, 2, 2),
             decimal_places = 1,
             endtime = endtime,
             outfile = outfile)
@@ -123,9 +120,9 @@ def test__verify__third_order_spatial_convergence__via_mms(
             sim_module = sim_module,
             sim_kwargs = sim_kwargs,
             manufactured_solution = space_verification_solution,
-            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32)],
-            norms = (None, "H1", "H1"),
-            expected_orders = (None, 3, 3),
+            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32, 64)],
+            norms = ("L2", "H1", "H1"),
+            expected_orders = (3, 3, 3),
             decimal_places = 1,
             endtime = endtime,
             outfile = outfile)

--- a/tests/verification/test__enthalpy_porosity.py
+++ b/tests/verification/test__enthalpy_porosity.py
@@ -94,7 +94,7 @@ def test__verify__second_order_spatial_convergence__via_mms(
             manufactured_solution = space_verification_solution,
             meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16)],
             norms = ("L2", "H1", "H1"),
-            expected_orders = (2, 2, 2),
+            expected_orders = (None, 2, 2),
             decimal_places = 1,
             endtime = endtime,
             outfile = outfile)
@@ -120,9 +120,9 @@ def test__verify__third_order_spatial_convergence__via_mms(
             sim_module = sim_module,
             sim_kwargs = sim_kwargs,
             manufactured_solution = space_verification_solution,
-            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32, 64)],
+            meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32)],
             norms = ("L2", "H1", "H1"),
-            expected_orders = (3, 3, 3),
+            expected_orders = (None, 3, 3),
             decimal_places = 1,
             endtime = endtime,
             outfile = outfile)
@@ -133,9 +133,7 @@ def test__verify__second_order_temporal_convergence__via_mms(
     
     sim_kwargs["element_degree"] = (1, 2, 2)
     
-    meshsize = 32
-    
-    sim_kwargs["mesh"] = fe.UnitSquareMesh(meshsize, meshsize)
+    sim_kwargs["mesh"] = fe.UnitSquareMesh(32, 32)
     
     testdir = "{}/{}/".format(
         __name__.replace(".", "/"), sys._getframe().f_code.co_name)

--- a/tests/verification/test__navier_stokes_boussinesq.py
+++ b/tests/verification/test__navier_stokes_boussinesq.py
@@ -22,6 +22,10 @@ def manufactured_solution(sim):
     
     T = sin(2.*pi*x)*sin(pi*y)
     
+    mean_pressure = fe.assemble(p*fe.dx)
+    
+    p -= mean_pressure
+    
     return p, u, T
     
     
@@ -36,29 +40,6 @@ def test__verify_spatial_accuracy_via_mms():
         sim_kwargs = {
             "grashof_number": Ra/Pr,
             "prandtl_number": Pr,
-            "element_degree": (1, 2, 2),
-            },
-        manufactured_solution = manufactured_solution,
-        meshes = [fe.UnitSquareMesh(n, n) for n in (4, 8, 16, 32, 64)],
-        norms = ("L2", "H1", "H1"),
-        expected_orders = (2, 2, 2),
-        decimal_places = 1)
-
-    
-def test__verify_spatial_accuracy_with_pressure_penalty_via_mms():
-    
-    Ra = 10.
-    
-    Pr = 0.7
-    
-    gamma = 1.e-7
-    
-    sapphire.mms.verify_spatial_order_of_accuracy(
-        sim_module = sim_module,
-        sim_kwargs = {
-            "grashof_number": Ra/Pr, 
-            "prandtl_number": Pr, 
-            "pressure_penalty_constant": gamma,
             "element_degree": (1, 2, 2),
             },
         manufactured_solution = manufactured_solution,

--- a/tests/verification/test__unsteady_navier_stokes_boussinesq.py
+++ b/tests/verification/test__unsteady_navier_stokes_boussinesq.py
@@ -24,6 +24,10 @@ def space_verification_solution(sim):
     
     T = sin(2.*pi*x)*sin(pi*y)
     
+    mean_pressure = fe.assemble(p*fe.dx)
+    
+    p -= mean_pressure
+    
     return p, u, T
     
 
@@ -46,6 +50,10 @@ def time_verification_solution(sim):
     p = -0.5*sin(pi*x)*sin(pi*y)
     
     T = exp(t)*sin(2.*pi*x)*sin(pi*y)
+    
+    mean_pressure = fe.assemble(p*fe.dx)
+    
+    p -= mean_pressure
     
     return p, u, T
     


### PR DESCRIPTION
This works for Navier-Stokes, Navier-Stokes-Boussinesq, and enthalpy porosity (including wax melting and water freezing).

The magnitude of the pressure error is still large in MMS verification of the enthalpy porosity method, and it's order of convergence seems consistently one order too high (when checking for second and third order convergence, instead get third and fourth order).

This PR also cleans up some continuation routines and cleans up the water freezing example.